### PR TITLE
Recognise apt.dat created by WED 1.50

### DIFF
--- a/files.py
+++ b/files.py
@@ -19,7 +19,7 @@ def parseapt(folder, secondary, missing, nobackup, names, f, parent):
     try:
         if not h.readline().strip(' \t\xef\xbb\xbf')[0] in ['I','A']:	# Also strip UTF-8 BOM
             raise IOError
-        if not h.readline().split()[0] in ['600','703','715','810','850','1000']:
+        if not h.readline().split()[0] in ['600','703','715','810','850','1000','1050']:
             raise IOError
         h.close()
     except:


### PR DESCRIPTION
New WED 1.50 exports apt.dat -files where the version header has been updated to 1050 due to the inclusion of new metadata-fields. This commit allows X-Publish to recognise these files as proper X-Plane format.
